### PR TITLE
Remove the usage of "Environments" GitHub feature

### DIFF
--- a/.github/workflows/acceptance_tests_lite.yaml
+++ b/.github/workflows/acceptance_tests_lite.yaml
@@ -11,7 +11,6 @@ jobs:
   # Lite acceptance tests run on zerocloud provider only, which makes them really fast,
   # but with limited coverage
   acceptance_lite:
-    environment: Acceptance Tests
     name: Acceptance Tests Lite (Terraform ${{ matrix.terraform-version }})
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
The "Environments" GitHub feature is not available in the main terraform-provider-vmc repository

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>