### PR TITLE
Sync Cluster EDRS properties with SDDC EDRS properties

### DIFF
--- a/vmc/resource_vmc_cluster.go
+++ b/vmc/resource_vmc_cluster.go
@@ -379,30 +379,34 @@ func clusterSchema() map[string]*schema.Schema {
 				"15TB", "20TB", "25TB", "30TB", "35TB"}, false),
 		},
 		"edrs_policy_type": {
-			Type:     schema.TypeString,
+			Type: schema.TypeString,
+			// Exact value known after create
 			Optional: true,
-			Default:  StorageScaleUpPolicyType,
+			Computed: true,
 			ValidateFunc: validation.StringInSlice(
 				[]string{StorageScaleUpPolicyType, CostPolicyType, PerformancePolicyType, RapidScaleUpPolicyType}, false),
 			Description: "The EDRS policy type. This can either be 'cost', 'performance', 'storage-scaleup' or 'rapid-scaleup'. Default : storage-scaleup. ",
 		},
 		"enable_edrs": {
-			Type:        schema.TypeBool,
+			Type: schema.TypeBool,
+			// Value can be changed after create
 			Optional:    true,
-			Default:     true,
+			Computed:    true,
 			Description: "True if EDRS is enabled",
 		},
 		"min_hosts": {
-			Type:         schema.TypeInt,
-			Default:      MinHosts,
+			Type: schema.TypeInt,
+			// Exact value known after create
 			Optional:     true,
+			Computed:     true,
 			ValidateFunc: validation.IntBetween(MinHosts, MaxHosts),
 			Description:  "The minimum number of hosts that the cluster can scale in to.",
 		},
 		"max_hosts": {
-			Type:         schema.TypeInt,
-			Default:      MaxHosts,
+			Type: schema.TypeInt,
+			// Exact value known after create
 			Optional:     true,
+			Computed:     true,
 			ValidateFunc: validation.IntBetween(MinHosts, MaxHosts),
 			Description:  "The maximum number of hosts that the cluster can scale out to.",
 		},


### PR DESCRIPTION
The nature of the EDRS properties is that they are not known until a cluster is deployed, thus any default values are likely going to be immediately out of date. The optional computed behavior fits the use-case.

Testing done:
make build
make test
golangci-lint run

make testacc TESTARGS="-run='TestAccResourceVmcSddcZerocloud|TestAccResourceVmcSrmNodeZerocloud|TestAccResourceVmcClusterZerocloud|TestAccResourceVmcSiteRecoveryZerocloud|TestAccDataSourceVmcCustomerSubnetsBasic' -parallel 4"

Signed-off-by: Dimitar Proynov <proynovd@vmware.com>